### PR TITLE
chore: drop support for Node.js 0.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "repository": "https://github.com/zachgarwood/ember-socrata",
   "engines": {
-    "node": ">= 0.10.0"
+    "node": ">= 4"
   },
   "author": "Zach Garwood <zachgarwood@gmail.com> (http://zachgarwood.com)",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "repository": "https://github.com/zachgarwood/ember-socrata",
   "engines": {
-    "node": ">= 4"
+    "node": ">= 0.12"
   },
   "author": "Zach Garwood <zachgarwood@gmail.com> (http://zachgarwood.com)",
   "license": "MIT",


### PR DESCRIPTION
BREAKING CHANGE: This module no longer supports Node.js 0.10