### PR TITLE
fix select condition and add group option

### DIFF
--- a/addon/adapters/socrata.js
+++ b/addon/adapters/socrata.js
@@ -74,7 +74,11 @@ export default Adapter.extend({
       }
 
       if ('select' in query) {
-        queryBuilder.order(...query['select']);
+        queryBuilder.select(...query['select']);
+      }
+
+      if ('group' in query) {
+        queryBuilder.group(...query['group']);
       }
 
       if ('q' in query) {


### PR DESCRIPTION
This fixes the select condition in the adapter that was checking for `select` in the query object but incorrectly using `queryBuilder.order`. It also adds the `group` option that is supported by the Soda api.